### PR TITLE
fixing a few minor problems

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,8 @@
 cmake_minimum_required(VERSION 3.21 FATAL_ERROR)
 
-find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)
-find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PATH)
-
-set(CMAKE_CXX_STANDARD 17)
-
 project(systematicstools VERSION 02.00.00 LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "C++ Standard to use when compiling")
 
 #Changes default install path to be a subdirectory of the build dir.
 #Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path
@@ -19,6 +16,11 @@ endif()
 if(CMAKE_BUILD_TYPE STREQUAL "")
   set(CMAKE_BUILD_TYPE DebWithRelInfo)
 endif()
+
+message(STATUS "INFO: CMAKE_C_COMPILER ${CMAKE_C_COMPILER}")
+message(STATUS "INFO: CMAKE_CXX_COMPILER ${CMAKE_CXX_COMPILER}")
+message(STATUS "INFO: CMAKE_CXX_STANDARD ${CMAKE_CXX_STANDARD}")
+message(STATUS "INFO: CMAKE_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX}")
 
 LIST(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules)
 include(CPM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PA
 
 set(CMAKE_CXX_STANDARD 17)
 
-project(systematicstools VERSION 24.01 LANGUAGES CXX)
+project(systematicstools VERSION 02.00.00 LANGUAGES CXX)
 
 #Changes default install path to be a subdirectory of the build dir.
 #Can set build dir at configure time with -DCMAKE_INSTALL_PREFIX=/install/path

--- a/cmake/Modules/Findfhiclcppstandalone.cmake
+++ b/cmake/Modules/Findfhiclcppstandalone.cmake
@@ -19,7 +19,6 @@ cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
 set(FHICLCPP_SUITE_VERSION 4_18_01)
 string(REPLACE "_" "." FHICLCPP_SUITE_VERSION_DOT ${FHICLCPP_SUITE_VERSION})
 
-set(CMAKE_CXX_STANDARD 17)
 set(CXX_STANDARD_REQUIRED ON)
 
 #Changes default install path to be a subdirectory of the build dir.

--- a/src/systematicstools/interface/SystParamHeader.hh
+++ b/src/systematicstools/interface/SystParamHeader.hh
@@ -24,7 +24,7 @@ constexpr double const kDefaultDouble = 0xdeadbeef;
 /// Often specialized with paramId_t when requesting the Id of a named
 /// parameter, or with size_t when requesting the index of a parameter.
 template <typename T> T kParamUnhandled = std::numeric_limits<T>::max();
-template <> constexpr double const kParamUnhandled<double> = kDefaultDouble;
+template <> inline constexpr double const kParamUnhandled<double> = kDefaultDouble;
 
 /// Exception to be thrown when a SystParamHeader fails Validate
 /// N.B. It is not thrown by the validate method upon failure, but should be


### PR DESCRIPTION
This PR updates CMakeLists.txt to appropriate modern cmake usage.  I've tested various scenarious and see no problems.  The INFO messages are there to help test the scenarios.  We note that since the project language is CXX, the `INFO: CMAKE_C_COMPILER` compiler line provides no useful information.

One needs to add CMAKE_CXX_STANDARD to the cache in order for it to be used when compiling.  No need to define it again in Findfhiclcppstandalone.cmake.

Clang++ found a variable that was defined twice.  The fix is trivial.

In general, it is preferred to set cmake variables with `-DCMAKE_XXX` when configuring.  For instance:
```
cmake \
      -DCMAKE_INSTALL_PREFIX=... d \
      -DCMAKE_BUILD_TYPE=... \
      -DCMAKE_C_COMPILER=gcc \
      -DCMAKE_CXX_COMPILER=g++ \
      -DCMAKE_CXX_STANDARD=17 \
     <path to source>
```

We are using this patch in our build for ups.