### PR TITLE
On-the-fly overriding of systematic shift size

### DIFF
--- a/src/systematicstools/interface/ISystProviderTool.hh
+++ b/src/systematicstools/interface/ISystProviderTool.hh
@@ -107,6 +107,16 @@ public:
   /// parameters before and after the call.
   bool ConfigureFromParameterHeaders(fhicl::ParameterSet const &ps);
 
+  /// \brief Override the stored configuration for a parameter's variations.
+  ///
+  /// Most useful if/when a downstream user wants to specify specific variations
+  /// in the process of a programmatic study, where those variations weren't known
+  /// at the time of configuration.  (See, e.g., NuSystematics/IGENIESystParamaterTool)
+  void OverrideVariations(paramId_t param, std::vector<double> const & vals)
+  {
+    GetParam(fSystMetaData, param).paramVariations = vals;
+  }
+
   //==== return 1-filled event_unit_response_t
   systtools::event_unit_response_t GetDefaultEventResponse() const;
 

--- a/src/systematicstools/utility/FHiCLSystParamHeaderUtility.hh
+++ b/src/systematicstools/utility/FHiCLSystParamHeaderUtility.hh
@@ -3,6 +3,7 @@
 #include "systematicstools/utility/exceptions.hh"
 #include "fhiclcpp/fwd.h"
 
+#include <cstdint>
 #include <string>
 
 namespace systtools {


### PR DESCRIPTION
NOvA is in the process of implementing an interface for NuSystematics in its NOvARwgt package (where reweightable cross section systematics live).  The paradigm that NOvA has been working with for many years requests individual variations of systematic knobs one at a time, sometimes on-the-fly.  The current infrastructure of NuSystematics, where it's assumed that all the variations intended by the user are declared, makes this relatively cumbersome.

At @luketpickering 's suggestion, this PR adds a mechanism for overriding a shift from configuration on-the-fly, needed for the changes to nusystematics that will sit on top of it..